### PR TITLE
Fix: Add pinMode(drdyPin, INPUT) in init()

### DIFF
--- a/src/ADS1220_WE.cpp
+++ b/src/ADS1220_WE.cpp
@@ -92,6 +92,9 @@ uint8_t ADS1220_WE::init(){
 #endif
 
     setSPIClockSpeed(spiClock);
+    if(!(drdyPin < 0)){
+        pinMode(drdyPin, INPUT);
+    }
     if(!(csPin < 0)){
         pinMode(csPin, OUTPUT);
         digitalWrite(csPin, HIGH);


### PR DESCRIPTION
## Summary

The DRDY pin is never explicitly configured as `INPUT` in `init()`, which causes issues when sharing the SPI bus with other devices (e.g., RadioLib/SX1262) that may change GPIO state during their initialization.

On ESP32-C6, using ADS1220 alongside RadioLib caused `getRawData()` to hang forever waiting for DRDY, because the pin was left in an undefined state after RadioLib's SPI initialization.

## Fix

Add `pinMode(drdyPin, INPUT)` before the existing `pinMode(csPin, OUTPUT)` call in `init()`. This matches the existing pattern for the CS pin.

## Test

Tested on XIAO ESP32-C6 with ADS1220 and SX1262 (RadioLib) sharing the same SPI bus. Before the fix, `getRawData()` would hang. After the fix, both devices work correctly.